### PR TITLE
Refactor `SysLog` to not provide `Default` via companion object inheritance, but instead a static `SysLog.Companion.Debug` instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ class MyClass {
 
 fun main() {
     // Install desired Log implementation(s) at startup
-    Log.Root.install(SysLog.Default)
+    Log.Root.install(SysLog.Debug)
 
     val doSomethingResult = MyClass().doSomething("Hello!")
 
@@ -94,7 +94,7 @@ fun main() {
     )
     assertEquals(1, numberOfLogInstancesThatLoggedThisThing)
 
-    Log.Root.uninstall(SysLog.Default)
+    Log.Root.uninstall(SysLog.Debug)
     assertEquals(0, logger.e { throw IllegalStateException("Won't happen...") })
 
     // Create your own Log implementation(s) and install them.

--- a/library/log/src/commonMain/kotlin/io/matthewnelson/kmp/log/Log.kt
+++ b/library/log/src/commonMain/kotlin/io/matthewnelson/kmp/log/Log.kt
@@ -51,7 +51,7 @@ import kotlin.jvm.JvmSynthetic
  *
  *     val logger = Log.Logger.of(tag = "Example")
  *     logger.i { "This will not be logged" }
- *     Log.Root.install(SysLog.Default)
+ *     Log.Root.install(SysLog.Debug)
  *     logger.i { "This WILL be logged" }
  *     Log.Root.uninstall(SysLog.UID)
  *
@@ -1246,14 +1246,7 @@ public abstract class Log {
     }
     /** @suppress */
     public final override fun toString(): String {
-        var name = this::class.simpleName ?: "Log"
-        when {
-            name == "Default" -> when (uid) {
-                // An unfortunate side effect of not having KClass<*>.qualifiedName
-                // available from commonMain (Js/WasmJs/WasmWasi)
-                "io.matthewnelson.kmp.log.sys.SysLog" -> name = "SysLog.Default"
-            }
-        }
+        val name = this::class.simpleName ?: "Log"
         return "$name[min=$min, max=$max, uid=$uid]"
     }
 

--- a/library/sys/README.md
+++ b/library/sys/README.md
@@ -1,13 +1,13 @@
 # Module sys
 
-A `Log` implementation that formats, then prints the logs to system locations.
+A `Log` implementation that formats, then prints logs to system locations.
 
 e.g.
 
 ```kotlin
 fun main() {
-    Log.Root.install(SysLog.Default)
-    Log.Root.uninstall(log = SysLog.Default)
+    Log.Root.install(SysLog.Debug)
+    Log.Root.uninstall(log = SysLog.Debug)
     Log.Root.install(SysLog.of(min = Level.Warn))
     Log.Root.uninstall(uid = SysLog.UID)
 }

--- a/library/sys/api/android/sys.api
+++ b/library/sys/api/android/sys.api
@@ -1,14 +1,13 @@
-public class io/matthewnelson/kmp/log/sys/SysLog : io/matthewnelson/kmp/log/Log {
-	public static final field Default Lio/matthewnelson/kmp/log/sys/SysLog$Default;
+public final class io/matthewnelson/kmp/log/sys/SysLog : io/matthewnelson/kmp/log/Log {
+	public static final field Companion Lio/matthewnelson/kmp/log/sys/SysLog$Companion;
+	public static final field Debug Lio/matthewnelson/kmp/log/sys/SysLog;
 	public static final field UID Ljava/lang/String;
 	public synthetic fun <init> (Lio/matthewnelson/kmp/log/Log$Level;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun isInstalled ()Z
-	protected final fun isLoggable (Lio/matthewnelson/kmp/log/Log$Level;Ljava/lang/String;Ljava/lang/String;)Z
-	protected fun log (Lio/matthewnelson/kmp/log/Log$Level;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)Z
 	public static final fun of (Lio/matthewnelson/kmp/log/Log$Level;)Lio/matthewnelson/kmp/log/sys/SysLog;
 }
 
-public final class io/matthewnelson/kmp/log/sys/SysLog$Default : io/matthewnelson/kmp/log/sys/SysLog {
+public final class io/matthewnelson/kmp/log/sys/SysLog$Companion {
 	public final fun isInstalled ()Z
 	public final fun of (Lio/matthewnelson/kmp/log/Log$Level;)Lio/matthewnelson/kmp/log/sys/SysLog;
 }

--- a/library/sys/api/jvm/sys.api
+++ b/library/sys/api/jvm/sys.api
@@ -1,14 +1,13 @@
-public class io/matthewnelson/kmp/log/sys/SysLog : io/matthewnelson/kmp/log/Log {
-	public static final field Default Lio/matthewnelson/kmp/log/sys/SysLog$Default;
+public final class io/matthewnelson/kmp/log/sys/SysLog : io/matthewnelson/kmp/log/Log {
+	public static final field Companion Lio/matthewnelson/kmp/log/sys/SysLog$Companion;
+	public static final field Debug Lio/matthewnelson/kmp/log/sys/SysLog;
 	public static final field UID Ljava/lang/String;
 	public synthetic fun <init> (Lio/matthewnelson/kmp/log/Log$Level;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun isInstalled ()Z
-	protected final fun isLoggable (Lio/matthewnelson/kmp/log/Log$Level;Ljava/lang/String;Ljava/lang/String;)Z
-	protected final fun log (Lio/matthewnelson/kmp/log/Log$Level;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)Z
 	public static final fun of (Lio/matthewnelson/kmp/log/Log$Level;)Lio/matthewnelson/kmp/log/sys/SysLog;
 }
 
-public final class io/matthewnelson/kmp/log/sys/SysLog$Default : io/matthewnelson/kmp/log/sys/SysLog {
+public final class io/matthewnelson/kmp/log/sys/SysLog$Companion {
 	public final fun isInstalled ()Z
 	public final fun of (Lio/matthewnelson/kmp/log/Log$Level;)Lio/matthewnelson/kmp/log/sys/SysLog;
 }

--- a/library/sys/api/sys.klib.api
+++ b/library/sys/api/sys.klib.api
@@ -6,17 +6,16 @@
 // - Show declarations: true
 
 // Library unique name: <io.matthewnelson.kmp-log:sys>
-open class io.matthewnelson.kmp.log.sys/SysLog : io.matthewnelson.kmp.log/Log { // io.matthewnelson.kmp.log.sys/SysLog|null[0]
-    final fun isLoggable(io.matthewnelson.kmp.log/Log.Level, kotlin/String?, kotlin/String): kotlin/Boolean // io.matthewnelson.kmp.log.sys/SysLog.isLoggable|isLoggable(io.matthewnelson.kmp.log.Log.Level;kotlin.String?;kotlin.String){}[0]
-    final fun log(io.matthewnelson.kmp.log/Log.Level, kotlin/String?, kotlin/String, kotlin/String?, kotlin/Throwable?): kotlin/Boolean // io.matthewnelson.kmp.log.sys/SysLog.log|log(io.matthewnelson.kmp.log.Log.Level;kotlin.String?;kotlin.String;kotlin.String?;kotlin.Throwable?){}[0]
+final class io.matthewnelson.kmp.log.sys/SysLog : io.matthewnelson.kmp.log/Log { // io.matthewnelson.kmp.log.sys/SysLog|null[0]
+    final object Companion { // io.matthewnelson.kmp.log.sys/SysLog.Companion|null[0]
+        final const val UID // io.matthewnelson.kmp.log.sys/SysLog.Companion.UID|{}UID[0]
+            final fun <get-UID>(): kotlin/String // io.matthewnelson.kmp.log.sys/SysLog.Companion.UID.<get-UID>|<get-UID>(){}[0]
 
-    final object Default : io.matthewnelson.kmp.log.sys/SysLog { // io.matthewnelson.kmp.log.sys/SysLog.Default|null[0]
-        final const val UID // io.matthewnelson.kmp.log.sys/SysLog.Default.UID|{}UID[0]
-            final fun <get-UID>(): kotlin/String // io.matthewnelson.kmp.log.sys/SysLog.Default.UID.<get-UID>|<get-UID>(){}[0]
+        final val Debug // io.matthewnelson.kmp.log.sys/SysLog.Companion.Debug|{}Debug[0]
+            final fun <get-Debug>(): io.matthewnelson.kmp.log.sys/SysLog // io.matthewnelson.kmp.log.sys/SysLog.Companion.Debug.<get-Debug>|<get-Debug>(){}[0]
+        final val isInstalled // io.matthewnelson.kmp.log.sys/SysLog.Companion.isInstalled|{}isInstalled[0]
+            final fun <get-isInstalled>(): kotlin/Boolean // io.matthewnelson.kmp.log.sys/SysLog.Companion.isInstalled.<get-isInstalled>|<get-isInstalled>(){}[0]
 
-        final val isInstalled // io.matthewnelson.kmp.log.sys/SysLog.Default.isInstalled|{}isInstalled[0]
-            final fun <get-isInstalled>(): kotlin/Boolean // io.matthewnelson.kmp.log.sys/SysLog.Default.isInstalled.<get-isInstalled>|<get-isInstalled>(){}[0]
-
-        final fun of(io.matthewnelson.kmp.log/Log.Level): io.matthewnelson.kmp.log.sys/SysLog // io.matthewnelson.kmp.log.sys/SysLog.Default.of|of(io.matthewnelson.kmp.log.Log.Level){}[0]
+        final fun of(io.matthewnelson.kmp.log/Log.Level): io.matthewnelson.kmp.log.sys/SysLog // io.matthewnelson.kmp.log.sys/SysLog.Companion.of|of(io.matthewnelson.kmp.log.Log.Level){}[0]
     }
 }

--- a/library/sys/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidTestPlatform.kt
+++ b/library/sys/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidTestPlatform.kt
@@ -22,6 +22,6 @@ actual fun isNative(): Boolean = false
 actual fun deviceApiLevel(): Int = Build.VERSION.SDK_INT
 
 actual val IS_LOGGABLE_REQUIRED_API_LEVEL: Int = 0
-actual fun SysLog.Default.androidIsLoggable(level: Log.Level, domain: String?, tag: String): Boolean? {
+actual fun SysLog.Companion.androidIsLoggable(level: Log.Level, domain: String?, tag: String): Boolean? {
     return isLoggableOrNull(level, domain, tag)
 }

--- a/library/sys/src/androidMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/androidMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -27,11 +27,12 @@ import io.matthewnelson.kmp.log.sys.internal.commonOf
 import io.matthewnelson.kmp.log.sys.internal.jvmLogPrint
 
 // android
-public actual open class SysLog private actual constructor(
-    min: Level /* = Level.Debug */,
-): Log(UID, min) {
+public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_UID, min) {
 
-    public actual companion object Default: SysLog() {
+    public actual companion object {
+
+        @JvmField
+        public actual val Debug: SysLog = SysLog(Level.Debug)
 
         public actual const val UID: String = SYS_LOG_UID
 
@@ -78,7 +79,7 @@ public actual open class SysLog private actual constructor(
         }
     }
 
-    actual final override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
+    actual override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
         return isLoggableOrNull(level, domain, tag) ?: true
     }
 }

--- a/library/sys/src/androidNativeMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/androidNativeMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -43,11 +43,11 @@ import platform.posix.android_get_device_api_level
 import platform.posix.dlsym
 
 // androidNative
-public actual open class SysLog private actual constructor(
-    min: Level /* = Level.Debug */,
-): Log(UID, min) {
+public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_UID, min) {
 
-    public actual companion object Default: SysLog() {
+    public actual companion object {
+
+        public actual val Debug: SysLog = SysLog(Level.Debug)
 
         public actual const val UID: String = SYS_LOG_UID
 
@@ -101,7 +101,7 @@ public actual open class SysLog private actual constructor(
         private const val MAX_LEN_LOG: Int = 1_000
     }
 
-    actual final override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
+    actual override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
         val priority = level.toPriority()
         val _tag = androidDomainTag(android_get_device_api_level(), domain, tag)
         return androidLogChunk(msg, t, MAX_LEN_LOG) { chunk ->
@@ -109,7 +109,7 @@ public actual open class SysLog private actual constructor(
         }
     }
 
-    actual final override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
+    actual override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
         return isLoggableOrNull(level, domain, tag) ?: true
     }
 }

--- a/library/sys/src/androidNativeTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidNativeTestPlatform.kt
+++ b/library/sys/src/androidNativeTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidNativeTestPlatform.kt
@@ -22,6 +22,6 @@ actual fun isNative(): Boolean = true
 actual fun deviceApiLevel(): Int = android_get_device_api_level()
 
 actual val IS_LOGGABLE_REQUIRED_API_LEVEL: Int = 30
-actual fun SysLog.Default.androidIsLoggable(level: Log.Level, domain: String?, tag: String): Boolean? {
+actual fun SysLog.Companion.androidIsLoggable(level: Log.Level, domain: String?, tag: String): Boolean? {
     return isLoggableOrNull(level, domain, tag)
 }

--- a/library/sys/src/androidRuntimeMain/kotlin/io/matthewnelson/kmp/log/sys/internal/-AndroidRuntimePlatform.kt
+++ b/library/sys/src/androidRuntimeMain/kotlin/io/matthewnelson/kmp/log/sys/internal/-AndroidRuntimePlatform.kt
@@ -24,7 +24,7 @@ import kotlin.contracts.contract
 
 private const val MAX_LEN_TAG: Int = 23
 
-internal inline fun SysLog.Default.androidDomainTag(
+internal inline fun SysLog.Companion.androidDomainTag(
     DEVICE_SDK_INT: Int,
     domain: String?,
     tag: String,
@@ -35,7 +35,7 @@ internal inline fun SysLog.Default.androidDomainTag(
 }
 
 @OptIn(ExperimentalContracts::class)
-internal inline fun SysLog.Default.androidLogChunk(
+internal inline fun SysLog.Companion.androidLogChunk(
     msg: String?,
     t: Throwable?,
     maxLenLog: Int,

--- a/library/sys/src/androidRuntimeTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidRuntimeTestPlatform.kt
+++ b/library/sys/src/androidRuntimeTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidRuntimeTestPlatform.kt
@@ -21,4 +21,4 @@ expect fun isNative(): Boolean
 expect fun deviceApiLevel(): Int
 
 expect val IS_LOGGABLE_REQUIRED_API_LEVEL: Int
-expect fun SysLog.Default.androidIsLoggable(level: Log.Level, domain: String?, tag: String): Boolean?
+expect fun SysLog.Companion.androidIsLoggable(level: Log.Level, domain: String?, tag: String): Boolean?

--- a/library/sys/src/androidRuntimeTest/kotlin/io/matthewnelson/kmp/log/sys/internal/AndroidLogChunkTest.kt
+++ b/library/sys/src/androidRuntimeTest/kotlin/io/matthewnelson/kmp/log/sys/internal/AndroidLogChunkTest.kt
@@ -40,13 +40,13 @@ class AndroidLogChunkTest {
             }
             log.append(". CHARS[").append(log.length + 2).appendLine(']')
         }
-        Log.installOrThrow(SysLog)
+        Log.installOrThrow(SysLog.Debug)
         try {
             val tag = "Chunking" + if (isNative()) "Native" else "NonNative"
             val result = Log.Logger.of(tag = tag).i(log.toString())
             assertEquals(1, result)
         } finally {
-            Log.uninstallOrThrow(SysLog)
+            Log.uninstallOrThrow(SysLog.UID)
         }
     }
 }

--- a/library/sys/src/androidRuntimeTest/kotlin/io/matthewnelson/kmp/log/sys/internal/AndroidTagTest.kt
+++ b/library/sys/src/androidRuntimeTest/kotlin/io/matthewnelson/kmp/log/sys/internal/AndroidTagTest.kt
@@ -38,14 +38,14 @@ class AndroidTagTest {
             assertEquals(tag, actual)
         }
 
-        Log.installOrThrow(SysLog)
+        Log.installOrThrow(SysLog.Debug)
         try {
             val result = Log.Logger.of(tag = tag).i {
                 "Test tag of length[${tag.length}] works on all API levels and will not cause an exception"
             }
             assertEquals(1, result)
         } finally {
-            Log.uninstallOrThrow(SysLog)
+            Log.uninstallOrThrow(SysLog.UID)
         }
     }
 }

--- a/library/sys/src/commonMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/commonMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -31,7 +31,7 @@ import io.matthewnelson.kmp.log.Log
  *     - Darwin/Linux/MinGW: [fprintf](https://www.man7.org/linux/man-pages/man3/fprintf.3p.html) to `stdout`/`stderr`
  *
  * **NOTE:** This [Log] implementation is meant for **non-production** environments. Logging
- * to `stdout`/`stderr` in production is violence. For this reason, [Default.min] is configured
+ * to `stdout`/`stderr` in production is violence. For this reason, [Debug] is configured
  * with [Log.Level.Debug]. If you DO happen to choose violence for your production environment,
  * [SysLog.of] should be used to configure a more appropriate minimum [Log.Level].
  *
@@ -53,22 +53,22 @@ import io.matthewnelson.kmp.log.Log
  *
  * e.g.
  *
- *     Log.install(SysLog.Default)
+ *     Log.install(SysLog.Debug)
  *     Log.Logger.of(tag = "YourLogger").i("Hello World!")
  *     Log.Logger.of(tag = "YourLogger2", domain = "your.domain").w("Yo!")
  *
- *     // 10-17 22:19:16.179 D [kmp-log:log]Log.Root: SysLog[min=Verbose, max=Fatal, uid=io.matthewnelson.kmp.log.sys.SysLog].onInstall()
+ *     // 10-17 22:19:16.179 D [kmp-log:log]Log.Root: SysLog[min=Debug, max=Fatal, uid=io.matthewnelson.kmp.log.sys.SysLog].onInstall()
  *     // 10-17 22:19:16.179 I YourLogger: Hello World!
  *     // 10-17 22:19:16.181 W [your.domain]YourLogger2: Yo!
  * */
-public expect open class SysLog private constructor(
-    min: Level = Level.Debug,
-): Log {
+public expect class SysLog private constructor(min: Level): Log {
 
-    /**
-     * The default [SysLog] implementation with [SysLog.min] set to [Level.Debug].
-     * */
-    public companion object Default: SysLog {
+    public companion object {
+
+        /**
+         * A static instance of [SysLog], configured with [Level.Debug].
+         * */
+        public val Debug: SysLog
 
         /**
          * The [SysLog.uid] (i.e. `io.matthewnelson.kmp.log.sys.SysLog`).
@@ -84,14 +84,14 @@ public expect open class SysLog private constructor(
 
         /**
          * Instantiate a new [SysLog] instance with the specified minimum [Level]. If
-         * [Level] specified is the same as [Default], then [Default] will be returned.
+         * [Level] specified is the same as [Debug], then [Debug] will be returned.
          * */
         public fun of(
             min: Level,
         ): SysLog
     }
 
-    final override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean
+    override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean
 
-    final override fun isLoggable(level: Level, domain: String?, tag: String): Boolean
+    override fun isLoggable(level: Level, domain: String?, tag: String): Boolean
 }

--- a/library/sys/src/commonMain/kotlin/io/matthewnelson/kmp/log/sys/internal/-CommonPlatform.kt
+++ b/library/sys/src/commonMain/kotlin/io/matthewnelson/kmp/log/sys/internal/-CommonPlatform.kt
@@ -24,23 +24,22 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
-// NOTE: Never modify. If so, update SysLog.Default.UID documentation, and Log.toString()
+// NOTE: Never modify. If so, update SysLog.Companion.UID documentation
 internal const val SYS_LOG_UID: String = "io.matthewnelson.kmp.log.sys.SysLog"
 internal const val CR: Char = '\r'
 internal const val LF: Char = '\n'
 
-@Suppress("RedundantCompanionReference")
 internal inline fun ((min: Level) -> SysLog).commonOf(
     min: Level,
 ): SysLog {
-    if (min != SysLog.Default.min) return this(min)
-    return SysLog.Default
+    if (min != SysLog.Debug.min) return this(min)
+    return SysLog.Debug
 }
 
-internal inline fun SysLog.Default.commonIsInstalled(): Boolean = Log.Root[UID] != null
+internal inline fun SysLog.Companion.commonIsInstalled(): Boolean = Log.Root[UID] != null
 
 // TODO: Move to :log as Log.Util.simpleDomainTag?
-internal inline fun SysLog.Default.commonDomainTag(
+internal inline fun SysLog.Companion.commonDomainTag(
     domain: String?,
     tag: String,
 ): String {
@@ -49,7 +48,7 @@ internal inline fun SysLog.Default.commonDomainTag(
     return commonDomainTag(sb, domain, tag).toString()
 }
 
-internal inline fun SysLog.Default.commonDomainTag(
+internal inline fun SysLog.Companion.commonDomainTag(
     sb: StringBuilder,
     domain: String?,
     tag: String,
@@ -60,7 +59,7 @@ internal inline fun SysLog.Default.commonDomainTag(
     append(tag)
 }
 
-internal inline fun SysLog.Default.commonFormatDateTime(
+internal inline fun SysLog.Companion.commonFormatDateTime(
     month: Int,     // 1-12
     day: Int,       // 1-31
     hours: Int,     // 0-23
@@ -90,7 +89,7 @@ internal inline fun SysLog.Default.commonFormatDateTime(
 
 // TODO: Move to :log as Log.Util.simpleFormat?
 // Returns `null` if empty (no data to log)
-internal inline fun SysLog.Default.commonFormatLogOrNull(
+internal inline fun SysLog.Companion.commonFormatLogOrNull(
     level: Level,
     domain: String?,
     tag: String,
@@ -166,7 +165,7 @@ internal inline fun SysLog.Default.commonFormatLogOrNull(
 
 @OptIn(ExperimentalContracts::class)
 @Throws(IllegalArgumentException::class)
-internal inline fun SysLog.Default.commonLogChunk(
+internal inline fun SysLog.Companion.commonLogChunk(
     formatted: CharSequence,
     maxLenLog: Int,
     _print: (chunk: String) -> Boolean,

--- a/library/sys/src/commonTest/kotlin/io/matthewnelson/kmp/log/sys/SysLogUnitTest.kt
+++ b/library/sys/src/commonTest/kotlin/io/matthewnelson/kmp/log/sys/SysLogUnitTest.kt
@@ -33,23 +33,24 @@ class SysLogUnitTest {
     fun givenSysLog_whenUid_thenIsAsExpected() {
         val expected = "io.matthewnelson.kmp.log.sys.SysLog"
         assertEquals(expected, SysLog.UID)
-        assertEquals(expected, SysLog.uid)
+        assertEquals(expected, SysLog.Debug.uid)
     }
 
     @Test
-    fun givenSysLog_whenDefaultConstructor_thenMinIsLevelDebug() {
-        assertEquals(Level.Debug, SysLog.min)
+    fun givenSysLog_whenDebug_thenMinIsLevelDebug() {
+        assertEquals(Level.Debug, SysLog.Debug.min)
     }
 
     @Test
-    fun givenSysLog_whenOfWithNonDefaultValue_thenReturnsNewInstance() {
+    fun givenSysLog_whenOfWithNonDebugValue_thenReturnsNewInstance() {
         val actual = SysLog.of(min = Level.Info)
-        assertNotEquals(SysLog.Default, actual)
+        assertNotEquals(SysLog.Debug, actual)
     }
 
     @Test
-    fun givenSysLog_whenDefault_thenToStringStartsWithSysLogDotDefault() {
-        assertTrue(SysLog.toString().startsWith("SysLog.Default["))
+    fun givenSysLog_whenOfWithDebugValue_thenReturnsDebugInstance() {
+        val actual = SysLog.of(min = Level.Debug)
+        assertEquals(SysLog.Debug, actual)
     }
 
     @Test
@@ -60,10 +61,10 @@ class SysLogUnitTest {
     @Test
     fun givenIsInstalled_whenIsInstalled_thenReturnsTrue() {
         try {
-            Log.installOrThrow(SysLog)
+            Log.installOrThrow(SysLog.Debug)
             assertTrue(SysLog.isInstalled)
         } finally {
-            Log.uninstall(SysLog)
+            Log.uninstall(SysLog.UID)
         }
     }
 
@@ -86,13 +87,13 @@ class SysLogUnitTest {
 
     @Test
     fun givenSysLog_whenLogIsAllWhitespace_thenDoesNotLog() {
-        Log.install(SysLog)
+        Log.install(SysLog.Debug)
         try {
             assertEquals(true, LOG.isLoggable(Level.Error))
             assertEquals(0, LOG.e("    "))
             assertEquals(0, LOG.e("\n"))
         } finally {
-            Log.uninstall(SysLog)
+            Log.uninstall(SysLog.UID)
         }
     }
 }

--- a/library/sys/src/darwinMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/darwinMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -25,11 +25,11 @@ import io.matthewnelson.kmp.log.sys.internal.nativeIsLoggable
 import io.matthewnelson.kmp.log.sys.internal.nativeLogPrint
 
 // darwin
-public actual open class SysLog private actual constructor(
-    min: Level /* = Level.Debug */,
-): Log(UID, min) {
+public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_UID, min) {
 
-    public actual companion object Default: SysLog() {
+    public actual companion object {
+
+        public actual val Debug: SysLog = SysLog(Level.Debug)
 
         public actual const val UID: String = SYS_LOG_UID
 
@@ -40,11 +40,11 @@ public actual open class SysLog private actual constructor(
         ): SysLog = ::SysLog.commonOf(min)
     }
 
-    actual final override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
+    actual override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
         return nativeLogPrint(level, domain, tag, msg, t)
     }
 
-    actual final override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
+    actual override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
         return nativeIsLoggable(level)
     }
 }

--- a/library/sys/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -29,11 +29,11 @@ import io.matthewnelson.kmp.log.sys.internal.js.JsDate
 import io.matthewnelson.kmp.log.sys.internal.js.jsConsole
 
 // jsWasmJs
-public actual open class SysLog private actual constructor(
-    min: Level /* = Level.Debug */,
-): Log(UID, min) {
+public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_UID, min) {
 
-    public actual companion object Default: SysLog() {
+    public actual companion object {
+
+        public actual val Debug: SysLog = SysLog(Level.Debug)
 
         public actual const val UID: String = SYS_LOG_UID
 
@@ -44,7 +44,7 @@ public actual open class SysLog private actual constructor(
         ): SysLog = ::SysLog.commonOf(min)
     }
 
-    actual final override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
+    actual override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
         val formatted = run {
             val now = JsDate()
 
@@ -81,7 +81,7 @@ public actual open class SysLog private actual constructor(
         }
     }
 
-    actual final override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
+    actual override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
         return super.isLoggable(level, domain, tag)
     }
 }

--- a/library/sys/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/log/sys/internal/-JvmAndroidPlatform.kt
+++ b/library/sys/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/log/sys/internal/-JvmAndroidPlatform.kt
@@ -25,7 +25,7 @@ import java.util.Locale
 
 internal val SYS_LOG_TIME_FORMAT = SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.ENGLISH)
 
-internal inline fun SysLog.Default.jvmLogPrint(
+internal inline fun SysLog.Companion.jvmLogPrint(
     level: Level,
     domain: String?,
     tag: String,

--- a/library/sys/src/jvmMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/jvmMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -24,11 +24,12 @@ import io.matthewnelson.kmp.log.sys.internal.commonOf
 import io.matthewnelson.kmp.log.sys.internal.jvmLogPrint
 
 // jvm
-public actual open class SysLog private actual constructor(
-    min: Level /* = Level.Debug */,
-): Log(UID, min) {
+public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_UID, min) {
 
-    public actual companion object Default: SysLog() {
+    public actual companion object {
+
+        @JvmField
+        public actual val Debug: SysLog = SysLog(Level.Debug)
 
         public actual const val UID: String = SYS_LOG_UID
 
@@ -42,11 +43,11 @@ public actual open class SysLog private actual constructor(
         ): SysLog = ::SysLog.commonOf(min)
     }
 
-    actual final override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
+    actual override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
         return jvmLogPrint(level, domain, tag, msg, t)
     }
 
-    actual final override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
+    actual override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
         return super.isLoggable(level, domain, tag)
     }
 }

--- a/library/sys/src/linuxMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/linuxMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -25,11 +25,11 @@ import io.matthewnelson.kmp.log.sys.internal.nativeIsLoggable
 import io.matthewnelson.kmp.log.sys.internal.nativeLogPrint
 
 // linux
-public actual open class SysLog private actual constructor(
-    min: Level /* = Level.Debug */,
-): Log(UID, min) {
+public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_UID, min) {
 
-    public actual companion object Default: SysLog() {
+    public actual companion object {
+
+        public actual val Debug: SysLog = SysLog(Level.Debug)
 
         public actual const val UID: String = SYS_LOG_UID
 
@@ -40,11 +40,11 @@ public actual open class SysLog private actual constructor(
         ): SysLog = ::SysLog.commonOf(min)
     }
 
-    actual final override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
+    actual override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
         return nativeLogPrint(level, domain, tag, msg, t)
     }
 
-    actual final override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
+    actual override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
         return nativeIsLoggable(level)
     }
 }

--- a/library/sys/src/mingwMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/mingwMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -25,11 +25,11 @@ import io.matthewnelson.kmp.log.sys.internal.nativeIsLoggable
 import io.matthewnelson.kmp.log.sys.internal.nativeLogPrint
 
 // mingw
-public actual open class SysLog private actual constructor(
-    min: Level /* = Level.Debug */,
-): Log(UID, min) {
+public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_UID, min) {
 
-    public actual companion object Default: SysLog() {
+    public actual companion object {
+
+        public actual val Debug: SysLog = SysLog(Level.Debug)
 
         public actual const val UID: String = SYS_LOG_UID
 
@@ -40,11 +40,11 @@ public actual open class SysLog private actual constructor(
         ): SysLog = ::SysLog.commonOf(min)
     }
 
-    actual final override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
+    actual override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
         return nativeLogPrint(level, domain, tag, msg, t)
     }
 
-    actual final override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
+    actual override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
         return nativeIsLoggable(level)
     }
 }

--- a/library/sys/src/nativeMain/kotlin/io/matthewnelson/kmp/log/sys/internal/NativePlatform.kt
+++ b/library/sys/src/nativeMain/kotlin/io/matthewnelson/kmp/log/sys/internal/NativePlatform.kt
@@ -32,7 +32,7 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
-internal fun SysLog.Default.nativeDateTime(): CharSequence? {
+internal fun SysLog.Companion.nativeDateTime(): CharSequence? {
     val dateTime = IntArray(7)
     @OptIn(ExperimentalForeignApi::class)
     @Suppress("RemoveRedundantCallsOfConversionMethods")
@@ -54,7 +54,7 @@ internal fun SysLog.Default.nativeDateTime(): CharSequence? {
 // NOTE: Cannot be utilized for androidNative because
 // /proc/self/fd/{0/1/2} point to /dev/null
 @OptIn(ExperimentalContracts::class, ExperimentalForeignApi::class)
-internal inline fun SysLog.Default.nativeLogPrint(
+internal inline fun SysLog.Companion.nativeLogPrint(
     level: Level,
     domain: String?,
     tag: String,
@@ -74,10 +74,10 @@ internal inline fun SysLog.Default.nativeLogPrint(
 // NOTE: Cannot be utilized for androidNative because
 // /proc/self/fd/{0/1/2} point to /dev/null
 @OptIn(ExperimentalForeignApi::class)
-internal inline fun SysLog.Default.nativeIsLoggable(level: Level): Boolean = stdioOrNull(level) != null
+internal inline fun SysLog.Companion.nativeIsLoggable(level: Level): Boolean = stdioOrNull(level) != null
 
 @OptIn(ExperimentalForeignApi::class)
-internal inline fun SysLog.Default.stdioOrNull(level: Level): CPointer<FILE>? = when (level) {
+internal inline fun SysLog.Companion.stdioOrNull(level: Level): CPointer<FILE>? = when (level) {
     Level.Verbose,
     Level.Debug,
     Level.Info -> stdout

--- a/library/sys/src/wasmWasiMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/wasmWasiMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -27,11 +27,11 @@ import kotlin.wasm.unsafe.UnsafeWasmMemoryApi
 import kotlin.wasm.unsafe.withScopedMemoryAllocator
 
 // wasmWasi
-public actual open class SysLog private actual constructor(
-    min: Level /* = Level.Debug */,
-): Log(UID, min) {
+public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_UID, min) {
 
-    public actual companion object Default: SysLog() {
+    public actual companion object {
+
+        public actual val Debug: SysLog = SysLog(Level.Debug)
 
         public actual const val UID: String = SYS_LOG_UID
 
@@ -45,7 +45,7 @@ public actual open class SysLog private actual constructor(
         private const val STDERR_FILENO: Int = 2
     }
 
-    actual final override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
+    actual override fun log(level: Level, domain: String?, tag: String, msg: String?, t: Throwable?): Boolean {
         val formatted = run {
             val dateTime = wasiDateTime()
             commonFormatLogOrNull(level, domain, tag, msg, t, dateTime, omitLastNewLine = false) ?: return false
@@ -83,7 +83,7 @@ public actual open class SysLog private actual constructor(
         }
     }
 
-    actual final override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
+    actual override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
         return super.isLoggable(level, domain, tag)
     }
 }

--- a/library/sys/src/wasmWasiMain/kotlin/io/matthewnelson/kmp/log/sys/internal/WasmWasiPlatform.kt
+++ b/library/sys/src/wasmWasiMain/kotlin/io/matthewnelson/kmp/log/sys/internal/WasmWasiPlatform.kt
@@ -24,7 +24,7 @@ import kotlin.time.ExperimentalTime
 // logging, and to instead increase the supported KotlinVersion for Wasi
 // from KOTLIN_1_9 to KOTLIN_2_1 and use the stdlib's Instant.
 // See: https://github.com/Kotlin/kotlinx-datetime/tree/v0.6.2#note-about-time-zones-in-wasmwasi
-internal fun SysLog.Default.wasiDateTime(): CharSequence? {
+internal fun SysLog.Companion.wasiDateTime(): CharSequence? {
     // 2023-01-02T23:40:57.120Z
     val iso8601 = try {
         @OptIn(ExperimentalTime::class)


### PR DESCRIPTION
Closes #32 