### PR TITLE
Fix broken `WasmWasi` documentation links

### DIFF
--- a/library/log/src/commonMain/kotlin/io/matthewnelson/kmp/log/Log.kt
+++ b/library/log/src/commonMain/kotlin/io/matthewnelson/kmp/log/Log.kt
@@ -1139,7 +1139,7 @@ public abstract class Log {
      *  - Js/WasmJs:
      *      - Browser: Throw exception
      *      - Node.js: [process.abort](https://nodejs.org/api/process.html#processabort)
-     *  - WasmWasi: [proc_exit](https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-proc_exitrval-exitcode)
+     *  - WasmWasi: [proc_exit](https://github.com/WebAssembly/WASI/blob/wasi-0.1/preview1/docs.md#-proc_exitrval-exitcode)
      *  - Native:
      *      - Android:
      *          - API 30+: [__android_log_call_aborter](https://cs.android.com/android/platform/superproject/+/android-latest-release:system/logging/liblog/include/android/log.h;l=336)

--- a/library/sys/src/commonMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/commonMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -25,7 +25,7 @@ import io.matthewnelson.kmp.log.Log
  * - Android: [android.util.Log.println](https://developer.android.com/reference/android/util/Log#println(int,%20java.lang.String,%20java.lang.String))
  * - Jvm/AndroidUnitTest: [System.out](https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#out)/[System.err](https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#err)
  * - Js/WasmJs: [Console](https://developer.mozilla.org/en-US/docs/Web/API/console)
- * - WasmWasi: [fd_write](https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-fd_writefd-fd-iovs-ciovec_array---resultsize-errno) to `STDOUT_FILENO`/`STDERR_FILENO`
+ * - WasmWasi: [fd_write](https://github.com/WebAssembly/WASI/blob/wasi-0.1/preview1/docs.md#-fd_writefd-fd-iovs-ciovec_array---resultsize-errno) to `STDOUT_FILENO`/`STDERR_FILENO`
  * - Native:
  *     - Android: [__android_log_print](https://cs.android.com/android/platform/superproject/+/android-latest-release:system/logging/liblog/include/android/log.h;l=115)
  *     - Darwin/Linux/MinGW: [fprintf](https://www.man7.org/linux/man-pages/man3/fprintf.3p.html) to `stdout`/`stderr`


### PR DESCRIPTION
`preview1` documentation was moved from branch `main` to `wasi-0.1`, breaking documentation in the process. This fixes it.