### PR TITLE
Use value class for domain separation to wrap `CoroutineScope` of `LogLoop`

### DIFF
--- a/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/log/file/internal/-LogLoopScope.kt
+++ b/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/log/file/internal/-LogLoopScope.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.log.file.internal
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlin.jvm.JvmInline
+
+@JvmInline
+internal value class LogLoopScope private constructor(internal val scope: CoroutineScope) {
+    internal companion object {
+        @OptIn(ExperimentalContracts::class)
+        internal suspend inline fun <R> logLoopScope(
+            crossinline block: suspend LogLoopScope.() -> R,
+        ): R {
+            contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+            return coroutineScope { block(LogLoopScope(this)) }
+        }
+    }
+}


### PR DESCRIPTION
Part of #24 