### PR TITLE
Mitigate unnecessary boxing on `Android`/`AndroidNative` by returning a default instead of nullable

### DIFF
--- a/library/sys/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidTestPlatform.kt
+++ b/library/sys/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidTestPlatform.kt
@@ -22,6 +22,9 @@ actual fun isNative(): Boolean = false
 actual fun deviceApiLevel(): Int = Build.VERSION.SDK_INT
 
 actual val IS_LOGGABLE_REQUIRED_API_LEVEL: Int = 0
-actual fun SysLog.Companion.androidIsLoggable(level: Log.Level, domain: String?, tag: String): Boolean? {
-    return isLoggableOrNull(level, domain, tag)
-}
+actual fun SysLog.Companion.androidIsLoggable(
+    level: Log.Level,
+    domain: String?,
+    tag: String,
+    default: Boolean,
+): Boolean = isLoggableOrDefault(level, domain, tag, default)

--- a/library/sys/src/androidMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/androidMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -47,8 +47,8 @@ public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_U
 
         // Exposed for testing
         @JvmSynthetic
-        internal fun isLoggableOrNull(level: Level, domain: String?, tag: String): Boolean? {
-            if (Build.VERSION.SDK_INT <= 0) return null
+        internal fun isLoggableOrDefault(level: Level, domain: String?, tag: String, default: Boolean): Boolean {
+            if (Build.VERSION.SDK_INT <= 0) return default
             // TODO: Should `null` be passed for domain here and only check for tag?
             val _tag = androidDomainTag(Build.VERSION.SDK_INT, domain, tag)
             return android.util.Log.isLoggable(_tag, level.toPriority())
@@ -80,6 +80,6 @@ public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_U
     }
 
     actual override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
-        return isLoggableOrNull(level, domain, tag) ?: true
+        return isLoggableOrDefault(level, domain, tag, default = true)
     }
 }

--- a/library/sys/src/androidNativeMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
+++ b/library/sys/src/androidNativeMain/kotlin/io/matthewnelson/kmp/log/sys/SysLog.kt
@@ -59,8 +59,8 @@ public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_U
 
         // Exposed for testing
         @OptIn(ExperimentalForeignApi::class)
-        internal fun isLoggableOrNull(level: Level, domain: String?, tag: String): Boolean? {
-            val ___android_log_is_loggable = ANDROID_LOG_IS_LOGGABLE ?: return null
+        internal fun isLoggableOrDefault(level: Level, domain: String?, tag: String, default: Boolean): Boolean {
+            val ___android_log_is_loggable = ANDROID_LOG_IS_LOGGABLE ?: return default
             val priority = level.toPriority()
             // Do not need to use androidDomainTag b/c __android_log_is_loggable is only available
             // from API 30+, so no need to check device API level as the limitation on tag length
@@ -110,6 +110,6 @@ public actual class SysLog private actual constructor(min: Level): Log(SYS_LOG_U
     }
 
     actual override fun isLoggable(level: Level, domain: String?, tag: String): Boolean {
-        return isLoggableOrNull(level, domain, tag) ?: true
+        return isLoggableOrDefault(level, domain, tag, default = true)
     }
 }

--- a/library/sys/src/androidNativeTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidNativeTestPlatform.kt
+++ b/library/sys/src/androidNativeTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidNativeTestPlatform.kt
@@ -22,6 +22,9 @@ actual fun isNative(): Boolean = true
 actual fun deviceApiLevel(): Int = android_get_device_api_level()
 
 actual val IS_LOGGABLE_REQUIRED_API_LEVEL: Int = 30
-actual fun SysLog.Companion.androidIsLoggable(level: Log.Level, domain: String?, tag: String): Boolean? {
-    return isLoggableOrNull(level, domain, tag)
-}
+actual fun SysLog.Companion.androidIsLoggable(
+    level: Log.Level,
+    domain: String?,
+    tag: String,
+    default: Boolean,
+): Boolean = isLoggableOrDefault(level, domain, tag, default)

--- a/library/sys/src/androidRuntimeTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidRuntimeTestPlatform.kt
+++ b/library/sys/src/androidRuntimeTest/kotlin/io/matthewnelson/kmp/log/sys/-AndroidRuntimeTestPlatform.kt
@@ -21,4 +21,9 @@ expect fun isNative(): Boolean
 expect fun deviceApiLevel(): Int
 
 expect val IS_LOGGABLE_REQUIRED_API_LEVEL: Int
-expect fun SysLog.Companion.androidIsLoggable(level: Log.Level, domain: String?, tag: String): Boolean?
+expect fun SysLog.Companion.androidIsLoggable(
+    level: Log.Level,
+    domain: String?,
+    tag: String,
+    default: Boolean,
+): Boolean

--- a/library/sys/src/androidRuntimeTest/kotlin/io/matthewnelson/kmp/log/sys/AndroidIsLoggableTest.kt
+++ b/library/sys/src/androidRuntimeTest/kotlin/io/matthewnelson/kmp/log/sys/AndroidIsLoggableTest.kt
@@ -46,7 +46,11 @@ class AndroidIsLoggableTest {
                     Log.Level.Fatal -> true
                 }
 
-                assertEquals(expected, SysLog.androidIsLoggable(level, LOG.domain, LOG.tag), "$LOG >> $level")
+                assertEquals(
+                    expected,
+                    SysLog.androidIsLoggable(level, LOG.domain, LOG.tag, default = !expected),
+                    "$LOG >> $level",
+                )
                 assertEquals(expected, LOG.isLoggable(level), "$LOG >> $level")
             }
         } finally {


### PR DESCRIPTION
Closes #97 