### PR TITLE
Remove `FileLog.Builder` init block checks on `logDirectory`

### DIFF
--- a/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/log/file/FileLog.kt
+++ b/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/log/file/FileLog.kt
@@ -360,10 +360,6 @@ public class FileLog: Log {
 
     /**
      * TODO
-     *
-     * @throws [IllegalArgumentException] When:
-     *  - [logDirectory] is empty
-     *  - [logDirectory] contains null character `\u0000`
      * */
     public class Builder(
 
@@ -373,11 +369,6 @@ public class FileLog: Log {
         @JvmField
         public val logDirectory: String,
     ) {
-
-        init {
-            require(logDirectory.isNotEmpty()) { "logDirectory cannot be empty" }
-            require(!logDirectory.contains('\u0000')) { "logDirectory cannot contain null character '\\u0000'" }
-        }
 
         private var _min = Level.Info
         private var _max = Level.Fatal
@@ -850,8 +841,9 @@ public class FileLog: Log {
          *
          * @return The [FileLog] to [Log.Root.install]
          *
-         * @throws [IOException] If [File.canonicalFile2] fails.
+         * @throws [IOException] If [File.canonicalFile2] fails to resolve [logDirectory].
          * */
+        @Throws(Exception::class)
         public fun build(): FileLog {
             val fileName = _fileName
             val fileExtension = _fileExtension

--- a/library/file/src/commonTest/kotlin/io/matthewnelson/kmp/log/file/FileLogBuilderUnitTest.kt
+++ b/library/file/src/commonTest/kotlin/io/matthewnelson/kmp/log/file/FileLogBuilderUnitTest.kt
@@ -15,7 +15,6 @@
  **/
 package io.matthewnelson.kmp.log.file
 
-import io.matthewnelson.kmp.file.SysDirSep
 import io.matthewnelson.kmp.file.SysTempDir
 import io.matthewnelson.kmp.file.name
 import io.matthewnelson.kmp.file.path
@@ -89,26 +88,6 @@ class FileLogBuilderUnitTest {
         assertEquals(prefix.length + 24, fileLog.uid.length)
         assertEquals(24, fileLog.logFiles0Hash.length)
         assertTrue(fileLog.uid.endsWith(fileLog.logFiles0Hash))
-    }
-
-    @Test
-    fun givenLogDirectory_whenEmpty_thenThrowsIllegalArgumentException() {
-        try {
-            newBuilder("")
-            fail()
-        } catch (e: IllegalArgumentException) {
-            assertEquals("logDirectory cannot be empty", e.message)
-        }
-    }
-
-    @Test
-    fun givenLogDirectory_whenContainsNullCharacter_thenThrowsIllegalArgumentException() {
-        try {
-            newBuilder(SysTempDir.path + SysDirSep + '\u0000')
-            fail()
-        } catch (e: IllegalArgumentException) {
-            assertEquals("logDirectory cannot contain null character '\\u0000'", e.message)
-        }
     }
 
     @Test


### PR DESCRIPTION
Closes #100 